### PR TITLE
Update for CASA 5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN docker-apt-install libfreetype6 libsm6 libxi6 libxrender1 libxrandr2 libxfix
 # setup all required env variables
 ARG VERSION
 ENV VERSION=${VERSION}
-ENV RELEASE=casa-release-${VERSION}-el6
+ENV RELEASE=casa-release-${VERSION}.el6
 ENV USER root
 ENV HOME /root
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/${RELEASE}/bin

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-VERSION=4.6.0
-DOCKER_REPO=kernsuite/casa:$(VERSION)
+VERSION := 5.1.2-4
+DOCKER_REPO := kernsuite/casa:$(VERSION)
 
 
 .PHONY: build clean run upload download

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Docker files for casa 4.6
+Docker files for casa 5.1
 
 These files are used to create a casapy docker image.
 
@@ -7,8 +7,4 @@ usage:
  * `make download` will download casa tarball
  * `make build` will make a docker image
  * `make upload` will upload image to docker hub (auth required)
-
-Note that you don't need this repository to use the casa docker image, 
-you can just do `docker run -ti radioastro/casa` which will implicitly
-download the image from the docker hub.
 

--- a/download.sh
+++ b/download.sh
@@ -7,8 +7,8 @@ then
 fi
 
 VERSION=$1
-FILE=casa-release-${VERSION}-el6.tar.gz
-URL=https://svn.cv.nrao.edu/casa/linux_distro/release/el6/$FILE
+FILE=casa-release-${VERSION}.el6.tar.gz
+URL=https://casa.nrao.edu/download/distro/linux/release/el6/$FILE
 
 # make sure we are in the source folder
 HERE=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )


### PR DESCRIPTION
I have updated the files to work with the new CASA downloads for CASA 5.X. I have verified that it builds and runs using `make build` and `make run`.  I could not test `make upload`  but have a version stored on my [gitlab registry](registry.gitlab.com/mdlucas/radio-combine).